### PR TITLE
Move groupping of events

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Demo is available at [http://event-calendar.s3-website-us-west-1.amazonaws.com/]
     * `events` the events are retrieved from the `eventsByDay` dictionary that we prepared earlier. We are able to efficiently access the events for the day by using the `get` helper.
     * `isInCurrentMonth` which is used to style the days outside of the currently displayed month.
     * `isToday` is also used to use a specific style.
- 
-
+    
+### Update
+After writing the README, I realised that I could move the grouping of events into the `calendar-month` component instead of having it in the `queryEventsTask` on the `month` route. That way `calendar-month` is easier to use in other places as it would simply expect an array of events.
 
 ## Prerequisites
 

--- a/app/components/calendar-month/component.js
+++ b/app/components/calendar-month/component.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import moment from 'moment';
 import { get, getProperties } from '@ember/object';
 import { computed } from 'ember-decorators/object';
+import { makeArray } from '@ember/array';
 
 
 export default Component.extend({
@@ -12,6 +13,36 @@ export default Component.extend({
    * @type {Moment}
    */
   date: null,
+
+  /**
+   * A list of events to be displayed.
+   *
+   * @type {Array.<EventModel>}
+   */
+  events: null,
+
+  /**
+   * The format that is used on a Moment to match a key in `eventsByDay`
+   *
+   * @type {[type]}
+   */
+  format: 'YYYY-MM-DD',
+
+  /**
+   * the key in the disctionary is a string of the date in a special format and the value is the array of events
+   *
+   * @type {Object}
+   */
+  @computed('events.@each.launchDate', 'format')
+  get eventsByDay() {
+    const { events, format } = getProperties(this, 'events', 'format');
+
+    return events.reduce((result, event) => {
+      const key = moment(get(event, 'launchDate')).format(format);
+      result[key] = makeArray(result[key]).addObject(event); // could this be more Ember :joy:
+      return result;
+    }, {});
+  },
 
   /**
    * It is cheaper to create one instance of today here instead of `calendar-day` component. Performance :muscle:

--- a/app/components/calendar-month/template.hbs
+++ b/app/components/calendar-month/template.hbs
@@ -6,7 +6,7 @@
     {{calendar-day
       data-test-calendar-day-index=(concat weekIndex "-" dayIndex)
       date=day
-      events=(get eventsByDay (moment-format day "YYYY-MM-DD"))
+      events=(get eventsByDay (moment-format day format))
       isInCurrentMonth=(is-same date day precision="month")
       isToday=(is-same day today precision="day")}}
   {{/calendar-week}}

--- a/app/routes/calendar/year/month.js
+++ b/app/routes/calendar/year/month.js
@@ -43,18 +43,7 @@ export default Route.extend({
       timeout(1000) // this is the minum delay
     ]);
 
-    // the key in the disctionary is a string of the date in a special format and the value is the array of events
-    const result = queryResult.reduce((result, event) => {
-      const eventLaunchDateISOString = moment(get(event, 'launchDate')).format('YYYY-MM-DD');
-      if (isEmpty(result[eventLaunchDateISOString])) {
-        result[eventLaunchDateISOString] = [event];
-      } else {
-        result[eventLaunchDateISOString].push(event);
-      }
-      return result;
-    }, {});
-
-    return result;
+    return queryResult;
   }).restartable(),
 
   /**

--- a/app/templates/calendar/year/month.hbs
+++ b/app/templates/calendar/year/month.hbs
@@ -10,7 +10,7 @@
     {{#liquid-if queryEventsTask.isRunning use="fade"}}
       <div class="loading">Loading...</div>
     {{else}}
-      {{calendar-month date=model eventsByDay=queryEventsTask.value}}
+      {{calendar-month date=model events=queryEventsTask.value}}
     {{/liquid-if}}
   </div>
 {{/calendar-container}}


### PR DESCRIPTION
After writing the README, I realised that I could move the grouping of events into the `calendar-month` component instead of having it in the queryEventsTask on the month route. That way `calendar-month` is easier to use in other places as it would simply expect an array of events.